### PR TITLE
Add format version, notebook preview and CI

### DIFF
--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: compile-manifest
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  build-manifest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          wget https://raw.githubusercontent.com/bioimage-io/bioimage-io-models/master/requirements.txt
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Compile manifest file
+        run: |
+          wget https://raw.githubusercontent.com/bioimage-io/bioimage-io-models/master/src/compile_model_manifest.py
+          python compile_model_manifest.py
+
+      - name: Save build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: built-output
+          path: ./

--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -1,3 +1,4 @@
+format_version: 0.2.0
 config:
   id: zero
   name: ZeroCostDL4Mic

--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -18,6 +18,10 @@ config:
     - dataset
   url_root: https://raw.githubusercontent.com/oeway/ZeroCostDL4Mic/master
 
+application:
+  - id: Notebook Preview
+    source: https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html
+
 dataset:
   # see here for the format: https://bioimage.io/#/?show=contribute
   # replace this with your actual dataset
@@ -50,4 +54,6 @@ notebook:
         url: https://colab.research.google.com/github/HenriquesLab/ZeroCostDL4Mic/blob/master/Colab_notebooks/U-net_2D_ZeroCostDL4Mic.ipynb
     documentation: null
     tags: [UNet, segmentation, ZeroCostDL4Mic]
-    source: https://github.com/HenriquesLab/ZeroCostDL4Mic/raw/master/Colab_notebooks/U-net_2D_ZeroCostDL4Mic.ipynb
+    source: https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/U-net_2D_ZeroCostDL4Mic.ipynb
+    links:
+      - Notebook Preview

--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -16,6 +16,7 @@ config:
     - model
     - notebook
     - dataset
+  default_type: notebook
   url_root: https://raw.githubusercontent.com/oeway/ZeroCostDL4Mic/master
 
 application:


### PR DESCRIPTION
This PR adds:
 * set format_version to 0.2.0
 * add a notebook preview application and link the model to it, so one can click the preview icon without launching the colab.
 * add CI script for Github Actions, so each time the compilation of the manifest file will be checked.