### PR TITLE
add verify bioimageio manifest step

### DIFF
--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -36,3 +36,8 @@ jobs:
         with:
           name: built-output
           path: ./
+
+      - name: verify bioimageio manifest
+        run: |
+          pip install git+https://github.com/bioimage-io/python-bioimage-io.git
+          python -m pybio.spec verify-bioimageio-manifest manifest.bioimage.io.yaml


### PR DESCRIPTION
Hi!
at https://github.com/bioimage-io/python-bioimage-io we made a parser to verify a manifest.bioimage.io.yaml. 
It is primarily written to check model.yaml files and has only rudimentary support for other possible entries in a manifest, but it's a start. The goal is to achieve a consistent bioimage.io format.

I thought you might find this helpful to integrate into your pipeline and would appreciate any feedback/input for further development of the parser. 