### PR TITLE
Update EmbedSeg_2D_ZeroCostDL4Mic.ipynb

### DIFF
--- a/Colab_notebooks/Beta notebooks/EmbedSeg_2D_ZeroCostDL4Mic.ipynb
+++ b/Colab_notebooks/Beta notebooks/EmbedSeg_2D_ZeroCostDL4Mic.ipynb
@@ -1,21 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "EmbedSeg_2D_ZeroCostDL4Mic.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -153,6 +136,56 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "3Poz3HJcDBpc"
+      },
+      "source": [
+        "## **1.0. Upgrading PyPI and uninstalling incompatible dependencies**\n",
+        "---\n",
+        "<font size = 4> \n",
+        "\n",
+        "### To make sure the EmbedSeg network operates in Google colab, it is needed to do some adjustment concerning deafult installed packages and libraries prior to the installation of key dependencies. Once incompatible pacakges are uninstalled, it is needed to restart the session and then proceed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "ZmHpXTR6DDZU"
+      },
+      "outputs": [],
+      "source": [
+        "#@markdown ##Press play to Uninstall\n",
+        "print(\"============================================ Upgrading Python Package Installer (PyPI) ============================================\")\n",
+        "!pip3 install --upgrade pip -q\n",
+        "\n",
+        "print(\"================================================== Ignore the following warnings ==================================================\")\n",
+        "%pip uninstall matplotlib -y -q\n",
+        "%pip uninstall torch -y -q\n",
+        "%pip uninstall torchvision -y -q\n",
+        "%pip uninstall torchtext -y -q\n",
+        "%pip uninstall torchaudio -y -q\n",
+        "%pip uninstall fastai -y -q\n",
+        "%pip install matplotlib==3.6.2 -q"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "cu26a_viDECn"
+      },
+      "outputs": [],
+      "source": [
+        "#@markdown ##Press play to restart session\n",
+        "import os\n",
+        "os.kill(os.getpid(), 9)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "XuwTHSva_Y5K"
       },
       "source": [
@@ -163,10 +196,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ganhf1X64jd3",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "ganhf1X64jd3"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Press play to Install\n",
         "\n",
@@ -175,9 +210,9 @@
         "\n",
         "    print (\"Installing EmbedSeg and its dependencies... \")\n",
         "\n",
-        "    !pip install -q EmbedSeg\n",
-        "    !pip install -q torch==1.1.0 torchvision==0.3.0 torchtext\n",
-        "    \n",
+        "    %pip install git+https://github.com/juglab/EmbedSeg.git -q\n",
+        "    %pip install torch==1.5.1 -q\n",
+        "    %pip install torchvision==0.6.1 -q\n",
         "\n",
         "    print (\"Installing some extra packages... \")\n",
         "    !pip install -q wget\n",
@@ -198,10 +233,10 @@
         "\n",
         "    print (\"Installing EmbedSeg and its dependencies... \")\n",
         "\n",
-        "    !pip install  EmbedSeg\n",
-        "    !pip install  torch==1.1.0 torchvision==0.3.0 torchtext\n",
-        "    \n",
-        "  \n",
+        "    %pip install git+https://github.com/juglab/EmbedSeg.git\n",
+        "    %pip install torch==1.5.1 \n",
+        "    %pip install torchvision==0.6.1 \n",
+        "\n",
         "    print (\"Installing some extra packages... \")\n",
         "    !pip install  wget\n",
         "    !pip install  tifffile\n",
@@ -213,9 +248,7 @@
         "    !pip install  tkinterwidgets\n",
         "    !pip install  memory_profiler\n",
         "    %load_ext memory_profiler\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -230,10 +263,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Mys9KzzZjZsN",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "Mys9KzzZjZsN"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Load key dependencies\n",
         "\n",
@@ -247,7 +282,7 @@
         "\n",
         "\n",
         "\n",
-        "Notebook_version = '1.13'\n",
+        "Notebook_version = '1.13' # UPDATED 26.12.2022 by Amin\n",
         "Network = 'EmbedSeg 2D'\n",
         "\n",
         "%matplotlib inline\n",
@@ -322,29 +357,6 @@
         "\n",
         "#===========================================================\n",
         "\n",
-        "# Check if this is the latest version of the notebook\n",
-        "All_notebook_versions = pd.read_csv(\"https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Latest_Notebook_versions.csv\", dtype=str)\n",
-        "print('Notebook version: '+Notebook_version)\n",
-        "Latest_Notebook_version = All_notebook_versions[All_notebook_versions[\"Notebook\"] == Network]['Version'].iloc[0]\n",
-        "print('Latest notebook version: '+Latest_Notebook_version)\n",
-        "if Notebook_version == Latest_Notebook_version:\n",
-        "  print(\"This notebook is up-to-date.\")\n",
-        "else:\n",
-        "  print(bcolors.WARNING +\"A new version of this notebook has been released. We recommend that you download it at https://github.com/HenriquesLab/ZeroCostDL4Mic/wiki\")\n",
-        "\n",
-        "\n",
-        "\n",
-        "\n",
-        "def random_label_cmap(n=2**16, h = (0,1), l = (.4,1), s =(.2,.8)):\n",
-        "    h,l,s = np.random.uniform(*h,n), np.random.uniform(*l,n), np.random.uniform(*s,n)\n",
-        "    cols = np.stack([colorsys.hls_to_rgb(_h,_l,_s) for _h,_l,_s in zip(h,l,s)],axis=0)\n",
-        "    cols[0] = 0\n",
-        "    return matplotlib.colors.ListedColormap(cols)\n",
-        "\n",
-        "lbl_cmap = random_label_cmap()\n",
-        "\n",
-        "warnings.filterwarnings('ignore')\n",
-        "\n",
         "print ('--------------------------------------------------------------------------------------------------------')\n",
         "\n",
         "# Colors for the warning messages\n",
@@ -364,6 +376,34 @@
         "   BOLD = '\\033[1m'\n",
         "   UNDERLINE = '\\033[4m'\n",
         "   END = '\\033[0m'\n",
+        "\n",
+        "#===========================================================\n",
+        "\n",
+        "\n",
+        "# Check if this is the latest version of the notebook\n",
+        "All_notebook_versions = pd.read_csv(\"https://raw.githubusercontent.com/HenriquesLab/ZeroCostDL4Mic/master/Colab_notebooks/Latest_Notebook_versions.csv\", dtype=str)\n",
+        "print('Notebook version: '+Notebook_version)\n",
+        "Latest_Notebook_version = All_notebook_versions[All_notebook_versions[\"Notebook\"] == Network]['Version'].iloc[0]\n",
+        "print('Latest notebook version: '+Latest_Notebook_version)\n",
+        "if Notebook_version == Latest_Notebook_version:\n",
+        "  print(\"This notebook is up-to-date.\")\n",
+        "else:\n",
+        "  print(bcolors.WARNING +\"A new version of this notebook has been released. We recommend that you download it at https://github.com/HenriquesLab/ZeroCostDL4Mic/wiki\")\n",
+        "\n",
+        "print ('--------------------------------------------------------------------------------------------------------')\n",
+        "\n",
+        "def random_label_cmap(n=2**16, h = (0,1), l = (.4,1), s =(.2,.8)):\n",
+        "    h,l,s = np.random.uniform(*h,n), np.random.uniform(*l,n), np.random.uniform(*s,n)\n",
+        "    cols = np.stack([colorsys.hls_to_rgb(_h,_l,_s) for _h,_l,_s in zip(h,l,s)],axis=0)\n",
+        "    cols[0] = 0\n",
+        "    return matplotlib.colors.ListedColormap(cols)\n",
+        "\n",
+        "lbl_cmap = random_label_cmap()\n",
+        "\n",
+        "warnings.filterwarnings('ignore')\n",
+        "\n",
+        "print ('--------------------------------------------------------------------------------------------------------')\n",
+        "\n",
         "\n",
         "print (\"    ⬛                              🟪\")\n",
         "print (\"    ⬛⬛                         🟪🟪\")\n",
@@ -1259,9 +1299,7 @@
         "\n",
         "\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1302,10 +1340,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "zCvebubeSaGY",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "zCvebubeSaGY"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Run this cell to check if you have GPU access\n",
         "\n",
@@ -1320,9 +1360,7 @@
         "else:\n",
         "  print('You have GPU access')\n",
         "  !nvidia-smi"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1341,10 +1379,24 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
         "id": "01Djr8v-5pPk",
-        "cellView": "form"
+        "outputId": "abe238c9-b9b5-4996-f7db-59eedbf7d8c6"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Mounted at /content/gdrive\n"
+          ]
+        }
+      ],
       "source": [
         "#@markdown ##Play the cell to connect your Google Drive to Colab\n",
         "\n",
@@ -1364,9 +1416,7 @@
         "\n",
         "\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1430,24 +1480,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ewpNJ_I0Mv47",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "ewpNJ_I0Mv47"
       },
+      "outputs": [],
       "source": [
         "#@markdown ###Path to training images: \n",
-        "Training_source = \"\" #@param {type:\"string\"}\n",
+        "Training_source = \"/content/gdrive/MyDrive/Stardist/Training - Images\" #@param {type:\"string\"}\n",
         "#aka,training images\n",
         "\n",
-        "Training_target = \"\" #@param {type:\"string\"}\n",
+        "Training_target = \"/content/gdrive/MyDrive/Stardist/Training - Masks\" #@param {type:\"string\"}\n",
         "#aka,training masks\n",
         "\n",
         "#@markdown ### Model name and path:\n",
-        "model_name = \"\" #@param {type:\"string\"}\n",
-        "model_path = \"\" #@param {type:\"string\"}\n",
+        "model_name = \"2023\" #@param {type:\"string\"}\n",
+        "model_path = \"/content/gdrive/MyDrive/my model path\" #@param {type:\"string\"}\n",
         "\n",
         "#@markdown ### Other parameters for training:\n",
-        "number_of_epochs =   50#@param {type:\"number\"}\n",
+        "number_of_epochs =   1#@param {type:\"number\"}\n",
         "\n",
         "#by defualt model_choice is empty which leads to train from scractch if section 3.2. is left out.\n",
         "\n",
@@ -1619,9 +1671,7 @@
         "plt.savefig('/content/TrainingDataExample_EmbedSeg2D.png',bbox_inches='tight',pad_inches=0)\n",
         "\n",
         "#==========================================================\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1655,10 +1705,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "oGV5OCJBAtmR",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "oGV5OCJBAtmR"
       },
+      "outputs": [],
       "source": [
         "#Data augmentation\n",
         "\n",
@@ -1827,9 +1879,7 @@
         "  print(bcolors.WARNING+\"Data augmentation disabled\") \n",
         "\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1849,10 +1899,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "wre3Gygnnc73",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "wre3Gygnnc73"
       },
+      "outputs": [],
       "source": [
         "# @markdown ##Loading weights from a pre-trained network\n",
         "\n",
@@ -1958,9 +2010,7 @@
         "else:\n",
         "  print(bcolors.WARNING+'No pretrained nerwork will be used.')\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -1985,10 +2035,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "QltPDuE5i3L7",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "QltPDuE5i3L7"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Create the model and dataset objects\n",
         "\n",
@@ -2195,7 +2247,7 @@
         "                                         size = train_size, \n",
         "                                         batch_size = train_batch_size, \n",
         "                                         virtual_batch_multiplier = virtual_train_batch_multiplier, \n",
-        "                                         normalization_factor= normalization_factor,\n",
+        "                                        #  normalization_factor= normalization_factor,\n",
         "                                         one_hot = one_hot,\n",
         "                                         type = 'train')\n",
         "\n",
@@ -2210,7 +2262,7 @@
         "                                       size = val_size, \n",
         "                                       batch_size = val_batch_size, \n",
         "                                       virtual_batch_multiplier = virtual_val_batch_multiplier,\n",
-        "                                       normalization_factor= normalization_factor,\n",
+        "                                      #  normalization_factor= normalization_factor,\n",
         "                                       one_hot = one_hot,\n",
         "                                       type ='val',)\n",
         "\n",
@@ -2251,9 +2303,7 @@
         "  \n",
         "if os.path.exists(Test_target_temp):\n",
         "  shutil.rmtree(Test_target_temp)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2273,10 +2323,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "ahsXZk9tSlC3",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "ahsXZk9tSlC3"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Start Training\n",
         "from datetime import datetime\n",
@@ -2317,9 +2369,7 @@
         "#pdf_export(trained = True, augmentation = Use_Data_augmentation, pretrained_model = Use_pretrained_model)\n",
         "\n",
         "#===============================================================================\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2338,10 +2388,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "22FQ07fpslES",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "22FQ07fpslES"
       },
+      "outputs": [],
       "source": [
         "# model name and path\n",
         "#@markdown ###Do you want to assess the model you just trained ?\n",
@@ -2387,9 +2439,7 @@
         "else:\n",
         "  print(bcolors.WARNING+'!! WARNING: Indicate where you want to save the results')\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2413,10 +2463,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "XHsWQ9xYsu_M",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "XHsWQ9xYsu_M"
       },
+      "outputs": [],
       "source": [
         "\n",
         "#@markdown ##Play the cell to show a plot of training errors vs. epoch number\n",
@@ -2459,9 +2511,7 @@
         "else:\n",
         "  print(\"The loss and validation curves are not available for this pre-trained model\")\n",
         "\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2490,10 +2540,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "dwnU4cRJCpxq",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "dwnU4cRJCpxq"
       },
+      "outputs": [],
       "source": [
         "#@markdown ##Choose the folders that contain your Quality Control dataset\n",
         "\n",
@@ -2676,9 +2728,7 @@
         "  plt.savefig(full_QC_model_path+'/Quality Control/QC_example_data.png',bbox_inches='tight',pad_inches=0)\n",
         "\n",
         "#qc_pdf_export()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2719,10 +2769,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "7yo4gQzyDvPd",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "7yo4gQzyDvPd"
       },
+      "outputs": [],
       "source": [
         "#@markdown ### Provide the path to your dataset and to the folder where the prediction will be saved (Result folder), then play the cell to predict output on your unseen images.\n",
         "Data_folder = \"\" #@param {type:\"string\"}\n",
@@ -2820,16 +2872,16 @@
         "\n",
         "\n",
         "begin_evaluating(test_configs, verbose = Verbose, avg_bg = avg_bg/normalization_factor)\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "-N_f3TJ9E0Au",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "-N_f3TJ9E0Au"
       },
+      "outputs": [],
       "source": [
         "# @markdown ##Run this cell to display a randomly chosen input and its corresponding predicted output.\n",
         "\n",
@@ -2860,9 +2912,7 @@
         "  plt.axis('off')  \n",
         "  plt.imshow(Embeded)\n",
         "  plt.title(\"Embedding\") "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -2883,5 +2933,28 @@
         "\n"
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "EmbedSeg_2D_ZeroCostDL4Mic.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3.10.4 ('test-env')",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.4"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "0ba003b81fddc81d1ecd52eba27ead9b5b76b209b60d68f00c1129c464a99008"
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Uninstalling the incompatible decencies and re-installing tested versions that met the dependency requirement solved PyPI related issues. 

After reviewing the EmbedSeg PyPI release history and comparing its source code with the EmbedSeg GitHub repo, I noticed a number of changes, of which all resulted in our version of notebook to not run properly. 

So in the section relating to installing key dependencies, I did change the path that PIP retrieves EmbedSeg. From here on forward, we are installing EmbedSeg from its GitHub repo (which is by far the most updated version) 

%pip install git+https://github.com/juglab/EmbedSeg.git

Another point to consider was a minor change in the original train section of EmbedSeg. The variable normalization_factor in train_dataset_dict and val_dataset_dict are no longer needed on the updated EmbedSeg version, hence the two are muted. 

After implementing these changes and running the notebook, I did not encounter any issues.