### PR TITLE
Updating dependency to jupysql

### DIFF
--- a/requirements_files/2D_UNet_multilabel_requirements_simple.txt
+++ b/requirements_files/2D_UNet_multilabel_requirements_simple.txt
@@ -171,7 +171,7 @@ intervaltree==2.1.0
 ipykernel==5.3.4
 ipython==7.9.0
 ipython-genutils==0.2.0
-ipython-sql==0.3.9
+jupysql==0.6.2
 ipywidgets==7.7.1
 itsdangerous==1.1.0
 jax==0.3.25

--- a/requirements_files/2D_UNet_requirements_simple.txt
+++ b/requirements_files/2D_UNet_requirements_simple.txt
@@ -170,7 +170,7 @@ intervaltree==2.1.0
 ipykernel==5.3.4
 ipython==7.9.0
 ipython-genutils==0.2.0
-ipython-sql==0.3.9
+jupysql==0.6.2
 ipywidgets==7.7.1
 itsdangerous==1.1.0
 jax==0.3.25

--- a/requirements_files/3D_UNet_requirements_simple.txt
+++ b/requirements_files/3D_UNet_requirements_simple.txt
@@ -172,7 +172,7 @@ intervaltree==2.1.0
 ipykernel==5.3.4
 ipython==7.9.0
 ipython-genutils==0.2.0
-ipython-sql==0.3.9
+jupysql==0.6.2
 ipywidgets==7.7.1
 itsdangerous==1.1.0
 jax==0.3.25


### PR DESCRIPTION
Using jupysql will get you more features and support.
We forked the ipython-sql repo into jupysql so it’s still maintained and we can help the community and users solve bugs/issues while keeping backward compatibility. We’ve also added some cool new features so we thought it will help you to use its latest version