### PR TITLE
fix notebook preview id

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -413,7 +413,7 @@ collection:
   #------------------------------------- Notebooks ---------------------------------------------
 
   - type: application
-    id: Notebook Preview
+    id: notebook_preview
     source: https://raw.githubusercontent.com/bioimage-io/nbpreview/master/notebook-preview.imjoy.html
 
   - type: application


### PR DESCRIPTION
An id must not contain spaces and has preferably only lower case letters.