### PR TITLE
Added contact info for BMZ

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -30,6 +30,20 @@ config:
     - dataset
   default_type: application
   url_root: https://raw.githubusercontent.com/oeway/ZeroCostDL4Mic/master
+  docs: https://github.com/HenriquesLab/ZeroCostDL4Mic/wiki
+  contact:
+    - name: Ricardo Henriques
+      email: ricardo.henriquescorreia@utu.fi
+      github: paxcalpt
+      affiliation:
+        - name: UTU
+          url: https://www.utu.fi/en
+    - name: Guillaume Jacquemet
+      email: guillaume.jacquemet@abo.fi
+      github: guijacquemet
+      affiliation:
+      - name: Abo Akademi
+        url: https://www.abo.fi
 
 
   #------------------------------------- ZeroCostDL4Mic Datasets ---------------------------------------------


### PR DESCRIPTION
Due to changes on the available documentation for the BioImage Model Zoo ([bioimage.io](bioimage.io)) regarding the Community Partners, new contact info for ZeroCostDL4Mic needed to be added to the manifest.

cc: @esgomezm 