### PR TITLE
Fix DL4MiceEverywhere typo to DL4MicEverywhere in manifest

### DIFF
--- a/.github/workflows/update_manifest_dl4miceverywhere.yml
+++ b/.github/workflows/update_manifest_dl4miceverywhere.yml
@@ -1,4 +1,4 @@
-name: Update the manifest with DL4MiceEverywhere information
+name: Update the manifest with DL4MicEverywhere information
 on:
   # At 05:30 AM of every day
   schedule:
@@ -31,5 +31,5 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
             repository: ./ZeroCostDL4Mic
-            commit_message: GitHub Action - Update manifest with DL4MiceEverywhere information
+            commit_message: GitHub Action - Update manifest with DL4MicEverywhere information
           


### PR DESCRIPTION
Hi all,

I receive these emails and thought a typo may have slipped in a manifest.
![image](https://github.com/user-attachments/assets/e01af20d-5255-4671-9c30-01b24a8b3abb)


 I thought you might appreciate this very small fix suggestion :)

Thanks for all your great work!

Best,
Sebastien

